### PR TITLE
Adding dependency update for forged-cli for release

### DIFF
--- a/forged-cli/Cargo.toml
+++ b/forged-cli/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["forged", "cli", "hardware", "provision"]
 [dependencies]
 cynic = { version = "1.0.0", features = ["reqwest"] }
 tokio = { version = "1.15", features = ["macros", "rt-multi-thread"] }
-forged = { path = "../forged-rs" }
+forged = { version = "0.1" }
 serde_json = "1.0.75"
 clap = { version = "3.0.13", features = ["derive"] }
 probe-rs = "0.13.0"


### PR DESCRIPTION
This PR updates the dependencies of `forged-cli` to point to the now-released client.