### PR TITLE
Adding metadata for python release

### DIFF
--- a/forged-py/README.md
+++ b/forged-py/README.md
@@ -1,0 +1,12 @@
+# Forged Python Client
+
+This package is a client to interface with the forged.dev manufacturing/provisioning service.
+
+When used in the automated Forged provisioner UI, uploading data blocks can be accomplished as
+simply as:
+```py
+from forged import Forged
+
+async def main():
+    await Forged.upload_value("my_block", 10.0)
+```

--- a/forged-py/pyproject.toml
+++ b/forged-py/pyproject.toml
@@ -1,11 +1,28 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "forged"
+name = "forged-client"
 description = "Forged.dev Client library"
 version = "0.0.1"
+readme = "README.md"
+authors = [
+    { name = "Ryan Summers", email = "ryan.summers@vertigo-designs.com" },
+    { name = "Noah Hüsser", email = "noah@huesser.dev" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Manufacturing",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Scientific/Engineering",
+    "Topic :: System :: Hardware",
+]
+keywords = ["api", "client", "database", "embedded"]
 dependencies = [
     "gql[all]"
 ]
+
+[project.urls]
+Homepage = "https://forged.dev"


### PR DESCRIPTION
This PR supports https://github.com/forged-org/forged-clients/issues/4 by adding metadata for a python client release.