### PR TITLE
Adding support for querying all blocks

### DIFF
--- a/forged-py/CHANGELOG.md
+++ b/forged-py/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+* Support now added for querying uploaded blocks for the current run.

--- a/forged-py/README.md
+++ b/forged-py/README.md
@@ -9,4 +9,6 @@ from forged import Forged
 
 async def main():
     await Forged.upload_value("my_block", 10.0)
+    blocks = await Forged.blocks()
+    assert blocks["my_block"] == 10.0
 ```


### PR DESCRIPTION
This PR adds basic support for querying blocks for the current run.

TODO:
- [x] Specify change in a CHANGELOG