### PR TITLE
Feature/cli updates

### DIFF
--- a/forged-cli/Cargo.toml
+++ b/forged-cli/Cargo.toml
@@ -17,9 +17,9 @@ keywords = ["forged", "cli", "hardware", "provision"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cynic = { version = "1.0.0", features = ["reqwest"] }
+cynic = { version = "2", features = ["http-reqwest"] }
 tokio = { version = "1.15", features = ["macros", "rt-multi-thread"] }
-forged = { version = "0.1" }
+forged = { path = "../forged-rs" }
 serde_json = "1.0.75"
 clap = { version = "3.0.13", features = ["derive"] }
 probe-rs = "0.13.0"

--- a/forged-cli/Cargo.toml
+++ b/forged-cli/Cargo.toml
@@ -29,3 +29,4 @@ probe-rs-cli-util = "0.13.0"
 thiserror = "1.0.30"
 dotenv = "0.15"
 uuid = { version = "1", features = ["serde"] }
+semver = "1"

--- a/forged-cli/schema.graphql
+++ b/forged-cli/schema.graphql
@@ -24,15 +24,20 @@ type Attachment {
 
 type Binary {
 	id: UUID!
-	projectId: UUID!
+	creationDate: DateTime!
+	deletionDate: DateTime
+	chipId: UUID!
+	chip: Chip!
+	version: String!
 	versionMajor: Int!
 	versionMinor: Int!
 	versionPatch: Int!
+	analysis: BinaryAnalysis
+	active: Boolean!
 	parts: [BinaryPart!]!
-	project: Project!
-	"""
-	Get the size of the binary non-volatile memory in bytes.
-	"""
+}
+
+type BinaryAnalysis {
 	nvmSize: Int!
 }
 
@@ -48,11 +53,15 @@ type BinaryPart {
 	binaryId: UUID!
 	kind: BinaryKind!
 	memoryOffset: Int
-	image: [Int!]!
 	imageHash: [Int!]!
-	sizeInMemory: Int!
+	analysis: BinaryPartAnalysis
 	creationDate: NaiveDateTime!
 	changeDate: NaiveDateTime!
+}
+
+type BinaryPartAnalysis {
+	rtt: RttAnalysis!
+	nvmSize: Int!
 }
 
 type Block {
@@ -79,10 +88,8 @@ type Block {
 	
 	This automatically transfers the stored data into a slice of bytes which can be written
 	to device memory.
-	
-	Uses [`BlockSchema::to_bytes`] to transform the data.
 	"""
-	byteSlice: [Int!]!
+	byteSlice(chipId: UUID!): [Int!]!
 }
 
 type BlockSchema {
@@ -90,43 +97,69 @@ type BlockSchema {
 	isDeviceIdentifier: Boolean!
 	projectId: UUID!
 	name: String!
+	displayName: String!
 	schema: String!
 	generator: String
-	toBytes: String
-	fromBytes: String
-	memoryAddress: Int
-	length: Int
-	creationDate: NaiveDateTime!
-	deactivationDate: NaiveDateTime
-	source: BlockSource!
+	memorySource: MemoryEndpoint
+	memorySink(chipId: UUID!): MemoryEndpoint!
+	memorySinks: [MemoryEndpoint!]!
+	creationDate: DateTime!
 	active: Boolean!
+	deletionDate: DateTime
 	"""
 	Determine if this schema can be used for requirements.
 	"""
 	supportsRequirements: Boolean!
-}
-
-"""
-Indicates the source of data for a block.
-"""
-enum BlockSource {
-	INPUT
-	EXTERNAL
-	DERIVED
+	requirements: [Requirement!]!
 }
 
 
 type Chip {
+	id: UUID!
+	projectId: UUID!
 	name: String!
-	nvmSize: Int!
+	partNumber: String!
+	nvmSize: Int
+	active: Boolean!
+	creationDate: DateTime!
+	changeDate: DateTime!
+	deletionDate: DateTime
+	"""
+	Returns true if the chip part number is natively supported by probe-rs.
+	"""
+	isSupported: Boolean!
+	"""
+	Returns the newest binary for given project id according to semver.
+	"""
+	binaryNewest: Binary
+	binaries: [Binary!]!
+	binary(id: UUID!): Binary!
 }
+
+input ChipEndpoint {
+	chipId: UUID!
+	address: Int!
+	length: Int!
+	transform: String!
+}
+
+type DataBlock {
+	blockSchema: BlockSchema!
+}
+
+"""
+Implement the DateTime<Utc> scalar
+
+The input/output is a string in RFC3339 format.
+"""
+scalar DateTime
 
 type Device {
 	id: UUID!
 	name: String
 	projectId: UUID!
-	creationDate: NaiveDateTime!
-	changeDate: NaiveDateTime!
+	creationDate: DateTime!
+	changeDate: DateTime!
 	project: Project!
 	runs: [Run!]!
 	"""
@@ -135,6 +168,14 @@ type Device {
 	If no UUID is given, the most recent run is returned.
 	"""
 	run(id: UUID): Run!
+	"""
+	Whether or not the device is active.
+	"""
+	active: Boolean!
+	"""
+	The date when the device was deactivated.
+	"""
+	deletionDate: DateTime
 }
 
 type DeviceConnection {
@@ -158,13 +199,13 @@ An edge in a connection.
 """
 type DeviceEdge {
 	"""
-	A cursor for use in pagination
-	"""
-	cursor: String!
-	"""
 	The item at the end of the edge
 	"""
 	node: Device!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 type Family {
@@ -173,11 +214,80 @@ type Family {
 	owner: Owner!
 }
 
+input FinishStepData {
+	binaryId: UUID
+}
+
+type FlashChip {
+	chipId: UUID!
+	command: String
+	chip: Chip!
+}
+
 
 type Group {
 	id: UUID!
+	name: String!
+	users: [User!]!
+	creationDate: DateTime!
+	changeDate: DateTime!
+	projects: [Project!]!
 }
 
+
+input InputDataBlock {
+	blockSchemaId: UUID
+}
+
+input InputFlashChip {
+	chipId: UUID
+	command: String
+}
+
+input InputIntegrationsSettings {
+	telegram: InputTelegramSettings!
+	matrix: InputMatrixSettings!
+}
+
+input InputMatrixSettings {
+	rooms: [String!]!
+}
+
+input InputPlaybook {
+	version: Int
+	stations: [InputStation!]!
+}
+
+input InputProjectSettings {
+	integrations: InputIntegrationsSettings!
+}
+
+input InputRunCommand {
+	command: String
+	directory: String
+}
+
+input InputStation {
+	name: String
+	color: String
+	steps: [InputStep!]!
+}
+
+input InputStep {
+	id: UUID!
+	label: String
+	kind: InputStepKind!
+}
+
+input InputStepKind {
+	dataBlock: InputDataBlock
+	flashChip: InputFlashChip
+	runCommand: InputRunCommand
+}
+
+input InputTelegramSettings {
+	chatIds: [Int!]!
+}
 
 input InsertBinaryPart {
 	name: String
@@ -186,6 +296,11 @@ input InsertBinaryPart {
 	image: Upload!
 }
 
+
+type IntegrationsSettings {
+	telegram: TelegramSettings!
+	matrix: MatrixSettings!
+}
 
 """
 A scalar that can represent any JSON value.
@@ -197,8 +312,26 @@ type Log {
 	runId: UUID!
 	level: String!
 	message: String!
-	creationDate: NaiveDateTime!
+	creationDate: DateTime!
 	run: Run!
+}
+
+type MatrixSettings {
+	rooms: [String!]!
+}
+
+scalar MemoryAddress
+
+type MemoryEndpoint {
+	id: UUID!
+	schema: BlockSchema!
+	chip: Chip!
+	sink: Boolean!
+	address: MemoryAddress!
+	length: Int!
+	creationDate: DateTime!
+	active: Boolean!
+	deletionDate: DateTime
 }
 
 type MutationRoot {
@@ -206,7 +339,11 @@ type MutationRoot {
 	Creates a new device for given `project_id` and returns the device.
 	"""
 	deviceCreate: Device!
-	signIn(username: String!, password: String!): String!
+	"""
+	Delete a device, making it no longer appear as being linked to the project.
+	"""
+	deviceDelete(id: UUID!): UUID!
+	signIn(email: String!, password: String!): String!
 	"""
 	Sign in with a given OAuth provider.
 	
@@ -218,8 +355,8 @@ type MutationRoot {
 	This nonce is only required for real OIDC providers and not all OAuth providers.
 	"""
 	signInWithOauth(provider: String!, code: String!, csrfToken: String, nonce: String): String!
-	refresh(token: String!): String!
-	userCreate(username: String!, email: String!, password: String!): User!
+	refresh(token: String!, impersonate: UUID): String!
+	userCreate(email: String!, password: String!): User!
 	userConfirm(token: String!): Boolean!
 	userApprove(id: UUID!): UUID!
 	userResendConfirmCode(email: String!): Boolean!
@@ -230,16 +367,36 @@ type MutationRoot {
 	"""
 	changePassword(currentPassword: String!, newPassword: String!): Boolean!
 	"""
-	Creates a new binary record and retursn the ID of the created record.
+	Creates a new binary with the specified chip
 	"""
-	binaryCreate(projectId: UUID!, version: String!, parts: [InsertBinaryPart!]!): Binary!
+	binaryCreate(chipId: UUID!, version: String!, parts: [InsertBinaryPart!]!): Binary!
+	"""
+	Delete a binary, making it no longer appear as being linked to the project.
+	"""
+	binaryDelete(id: UUID!): UUID!
 	"""
 	Creates a new project for a user and returns the project upon successful creation.
 	"""
-	projectCreate(name: String!, chipName: String!): Project!
-	provisionerCreate(name: String!, projectId: UUID!): Provisioner!
+	projectCreate(name: String!, groupOwner: UUID): Project!
+	"""
+	Delete a project, making it no longer appear as being linked to the user.
+	"""
+	projectDelete(id: UUID!): UUID!
+	"""
+	Change the owner of a project to a new user or group
+	"""
+	projectTransfer(id: UUID!, ownerId: UUID!): UUID!
+	"""
+	Update settings on a project.
+	"""
+	projectSettingsUpdate(id: UUID!, settings: InputProjectSettings!): UUID!
+	provisionerCreate(name: String!, station: String!, projectId: UUID!): Provisioner!
 	provisionerRename(id: UUID!, name: String!): Provisioner!
-	provisionerDeactivate(id: UUID!): Provisioner!
+	provisionerAssignStation(id: UUID!, station: String!): Provisioner!
+	"""
+	Delete a provisioner, making it no longer appear as being linked to the project.
+	"""
+	provisionerDelete(id: UUID!): UUID!
 	provisionerRegenerateToken(id: UUID!): Provisioner!
 	"""
 	Creates a new log for given `project_id` and returns the log.
@@ -264,13 +421,16 @@ type MutationRoot {
 	"""
 	Creates a new block_schema and returns the block_schema.
 	"""
-	blockSchemaCreate(projectId: UUID!, name: String!, schema: String!, generator: String, toBytes: String, fromBytes: String, memoryAddress: Int, length: Int, source: BlockSource!, isDeviceIdentifier: Boolean!): BlockSchema!
+	blockSchemaCreate(projectId: UUID!, name: String!, schema: String!, generator: String, memorySource: ChipEndpoint, memorySinks: [ChipEndpoint!]!, isDeviceIdentifier: Boolean!): BlockSchema!
 	"""
 	Re-name a block schema
 	"""
 	blockSchemaRename(id: UUID!, name: String!): UUID!
 	blockSchemaSetIdentifier(id: UUID!, identifier: Boolean!): UUID!
-	blockSchemaDeactivate(id: UUID!): BlockSchema!
+	"""
+	Delete a block schema, making it no longer appear as being linked to the project.
+	"""
+	blockSchemaDelete(id: UUID!): UUID!
 	"""
 	Creates a new block for given `project_id` and returns the block.
 	"""
@@ -279,7 +439,11 @@ type MutationRoot {
 	"""
 	Creates a new run for the currently in-session device and returns the run.
 	"""
-	runCreate: Run!
+	runCreate(station: String!): Run!
+	"""
+	Creates a new run for an existing device and returns the run.
+	"""
+	runCreateFor(identifier: String!, station: String!): Run!
 	"""
 	Finish provisioning for a run.
 	"""
@@ -291,15 +455,31 @@ type MutationRoot {
 	"""
 	Start a provisioning step on the currently-active run.
 	"""
-	finishStep(passed: Boolean!): UUID!
+	finishStep(passed: Boolean!, data: FinishStepData): UUID!
 	"""
 	Create a new requirement for given `project_id`.
 	"""
 	requirementCreate(projectId: UUID!, schemaId: UUID!, name: String!, description: String, lowerLimit: Float, inclusiveLower: Boolean!, upperLimit: Float, inclusiveUpper: Boolean!): Requirement!
 	"""
-	Deactivate a requirement such that it is no longer checked.
+	Delete a requirement,making it no longer linked to the project.
 	"""
-	requirementDeactivate(id: UUID!): UUID!
+	requirementDelete(id: UUID!): UUID!
+	"""
+	Updates the draft playbook with the given new playbook.
+	"""
+	playbookUpdate(projectId: UUID!, playbook: InputPlaybook!): Boolean!
+	playbookSave(projectId: UUID!): Int!
+	"""
+	Creates a new project for a user and returns the project upon successful creation.
+	"""
+	chipCreate(projectId: UUID!, name: String!, partNumber: String!): Chip!
+	"""
+	Delete a chip, making it no longer appear as being linked to the project.
+	"""
+	chipDelete(id: UUID!): UUID!
+	groupCreate(name: String!): Group!
+	groupAddUser(groupId: UUID!, userEmail: String!): UUID!
+	groupRemoveUser(groupId: UUID!, userId: UUID!): UUID!
 }
 
 """
@@ -310,6 +490,46 @@ ISO 8601 combined date and time without timezone.
 * `2015-07-01T08:59:60.123`,
 """
 scalar NaiveDateTime
+
+type Notification {
+	id: UUID!
+	projectId: UUID
+	event: JSON!
+	retry: Int!
+	creationDate: DateTime!
+	deliveryDate: DateTime
+	project: Project
+}
+
+type NotificationConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [NotificationEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Notification!]!
+	numNotifications: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type NotificationEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Notification!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
 
 type OauthData {
 	authUrl: String!
@@ -350,16 +570,32 @@ type PaymentMethod {
 	id: String!
 }
 
+type Playbook {
+	projectId: UUID!
+	version: Int
+	stations: [Station!]!
+	station(name: String!): Station
+	project: Project!
+}
+
 type Project {
 	id: UUID!
 	name: String!
-	chip: Chip!
-	binary(id: UUID!): Binary!
+	active: Boolean!
+	settings: ProjectSettings!
+	creationDate: DateTime!
+	changeDate: DateTime!
+	deletionDate: DateTime
+	chip(id: UUID!): Chip!
 	"""
-	Returns the newest binary for given project id according to semver.
+	Get the currently-active playbook for the project.
 	"""
-	binaryNewest: Binary
-	binaries: [Binary!]!
+	playbook: Playbook!
+	"""
+	Get all playbooks registered with the project.
+	"""
+	playbooks: [Playbook!]!
+	chips: [Chip!]!
 	device(id: UUID!): Device!
 	devices(after: String, first: Int, filter: String): DeviceConnection!
 	owner: Owner!
@@ -369,6 +605,11 @@ type Project {
 	blockSchema(id: UUID!): BlockSchema!
 	requirements: [Requirement!]!
 	requirement(id: UUID!): Requirement!
+	notifications(after: String, first: Int, filter: String): NotificationConnection!
+}
+
+type ProjectSettings {
+	integrations: IntegrationsSettings!
 }
 
 type Provisioner {
@@ -378,11 +619,13 @@ type Provisioner {
 	name: String!
 	token: String
 	active: Boolean!
-	creationDate: NaiveDateTime!
-	changeDate: NaiveDateTime!
+	creationDate: DateTime!
+	changeDate: DateTime!
 	project: Project!
 	currentDevice: Device
 	currentRun: Run
+	station: String!
+	steps: [Step!]!
 }
 
 type ProvisionerReleases {
@@ -396,6 +639,11 @@ type QueryRoot {
 	config: AppConfig!
 	currentUser: User!
 	usersPendingApproval: [User!]!
+	users: [User!]!
+	"""
+	Lists all projects.
+	"""
+	projects: [Project!]!
 	"""
 	Returns a project with a certain `id`.
 	"""
@@ -428,6 +676,7 @@ type QueryRoot {
 	Returns the data that is required for the frontend to work.
 	"""
 	provisionerReleases: ProvisionerReleases!
+	group(id: UUID!): Group!
 }
 
 type Release {
@@ -453,11 +702,11 @@ type Requirement {
 	"""
 	The date that the requirement was created.
 	"""
-	creationDate: NaiveDateTime!
+	creationDate: DateTime!
 	"""
 	The date when the requirement was deactivated.
 	"""
-	deactivationDate: NaiveDateTime
+	deletionDate: DateTime
 	"""
 	Whether or not the requirement is active.
 	"""
@@ -493,26 +742,31 @@ type RequirementCheck {
 	requirementId: UUID!
 	blockId: UUID
 	passed: Boolean!
-	checkDate: NaiveDateTime!
+	checkDate: DateTime!
 	runId: UUID!
 	requirement: Requirement!
 	block: Block
 }
 
+type RttAnalysis {
+	headerLocation: Int
+}
+
 type Run {
 	id: UUID!
 	deviceId: UUID!
-	currentStep: String!
 	projectId: UUID!
-	currentStepStatus: StepStatus!
-	creationDate: NaiveDateTime!
-	changeDate: NaiveDateTime!
+	provisioner: Provisioner
+	station: String!
+	creationDate: DateTime!
+	changeDate: DateTime!
 	finished: Boolean!
 	device: Device!
 	logs: [Log!]!
 	attachments: [Attachment!]!
 	blocks: [Block!]!
 	block(id: UUID!): Block!
+	blockForSchema(schemaId: UUID!): Block
 	blockSchemas: [BlockSchema!]!
 	requirementChecks: [RequirementCheck!]!
 	requirements: [Requirement!]!
@@ -520,7 +774,52 @@ type Run {
 	Get the overall status of the run.
 	"""
 	runStatus: StepStatus!
+	steps: [RunStep!]!
+	"""
+	Reports any reasons for a run failure.
+	"""
+	errors: [String!]!
 }
+
+type RunCommand {
+	command: String
+	directory: String
+}
+
+type RunStep {
+	id: UUID!
+	runId: UUID!
+	stepId: UUID!
+	status: StepStatus!
+	station: String!
+	creationDate: DateTime!
+	changeDate: DateTime!
+	data: RunStepData!
+	step: Step!
+}
+
+type RunStepData {
+	binaryId: UUID
+	binary: Binary
+}
+
+type Station {
+	name: String!
+	color: String!
+	steps: [Step!]!
+}
+
+type Step {
+	id: UUID!
+	kind: StepKind!
+	position: Int!
+	station: String!
+	label: String
+	creationDate: NaiveDateTime!
+	changeDate: NaiveDateTime!
+}
+
+union StepKind = DataBlock | FlashChip | RunCommand
 
 enum StepStatus {
 	PENDING
@@ -544,6 +843,10 @@ type SubscriptionRoot {
 	"""
 	createDeviceEvent(token: String!, projectId: UUID!): Device!
 	"""
+	Yields a new requirement whenever one is created.
+	"""
+	createRequirementEvent(token: String!, projectId: UUID!): Requirement!
+	"""
 	Yields a new device whenever a new device is created.
 	"""
 	logEvent(token: String!, runId: UUID!): Log!
@@ -565,9 +868,22 @@ type Target {
 	name: String!
 }
 
+type TelegramSettings {
+	chatIds: [Int!]!
+}
+
 enum Tier {
+	"""
+	Only a very limited free featureset.
+	"""
 	FREE
+	"""
+	The basic service with all it's basic features.
+	"""
 	BASE
+	"""
+	The full featureset unlocked.
+	"""
 	FULL
 }
 
@@ -588,14 +904,13 @@ scalar Upload
 type User {
 	id: UUID!
 	stripeCustomerId: String
-	username: String!
 	email: String!
 	tier: Tier!
 	admin: Boolean!
 	userType: UserType!
 	oauthUser: OauthUser
-	creationDate: NaiveDateTime!
-	changeDate: NaiveDateTime!
+	creationDate: DateTime!
+	changeDate: DateTime!
 	projects: [Project!]!
 	families: [Family!]!
 	groups: [Group!]!
@@ -607,6 +922,8 @@ enum UserType {
 	OAUTH
 }
 
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
 	query: QueryRoot
 	mutation: MutationRoot

--- a/forged-cli/src/cli.rs
+++ b/forged-cli/src/cli.rs
@@ -26,7 +26,10 @@ pub enum Command {
     Start,
 
     /// Downloads the binary and device data to the target.
-    Download,
+    Download {
+        chip: Option<String>,
+        version: Option<String>,
+    },
 
     /// Creates a new log entry on the device in the current session.
     #[clap(subcommand)]

--- a/forged-cli/src/functions/attach.rs
+++ b/forged-cli/src/functions/attach.rs
@@ -11,7 +11,7 @@ pub async fn attach(client: &mut forged::Client, file_path: String) -> Result<()
     let upload = forged::Upload::new(file_path.clone(), data);
     client
         .run_query_with_file_upload(
-            CreateAttachment::build(&CreateAttachmentArguments {
+            CreateAttachment::build(CreateAttachmentArguments {
                 data: upload.clone(),
             }),
             vec![upload],

--- a/forged-cli/src/functions/block.rs
+++ b/forged-cli/src/functions/block.rs
@@ -11,7 +11,7 @@ pub async fn block(client: &mut forged::Client, schema_name: String, data: Value
     println!("{data:#}");
 
     client
-        .run_query(CreateBlock::build(&CreateBlockArguments {
+        .run_query(CreateBlock::build(CreateBlockArguments {
             schema_name,
             data,
         }))

--- a/forged-cli/src/functions/download.rs
+++ b/forged-cli/src/functions/download.rs
@@ -6,44 +6,81 @@ use probe_rs::{
     flashing::{BinOptions, FlashLoader},
     Probe,
 };
+
+use crate::Error;
 use probe_rs_cli_util::{
     common_options::{CargoOptions, FlashOptions},
     flash,
 };
 
 use crate::{
-    queries::{Chips, BinaryPart},
+    queries::{Binary, Chip, Chips},
     Result,
 };
 
-pub async fn download(client: &mut forged::Client, chip: Option<String>, version: Option<String>) -> Result<()> {
+pub async fn download(
+    client: &mut forged::Client,
+    chip: Option<String>,
+    version: Option<String>,
+) -> Result<()> {
     println!("⛅ Grabbing binaries from the server ...");
 
     let query = client.run_query(Chips::build(())).await?;
     let chips = query.current_provisioner.project.chips;
 
-    let chip = if let Some(chip_name) = option.chip {
-        chips.find(|chip| chip.name == chip_name).ok_or_else(|| anyhow!("Chip {chip_name} not found. Available chips: {}", chips.iter().map(|chip| chip.name)))?
+    let chip = if let Some(chip_name) = chip {
+        chips
+            .iter()
+            .find(|chip| chip.name == chip_name)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Chip {chip_name} not found. Available chips: {:?}",
+                    chips.iter().map(|chip| chip.name.clone())
+                )
+            })?
     } else {
         match chips.len() {
-            0 => return Err(anyhow!("No chips have been configured for this project. Add one to the project first.")),
-            n => return Err(anyhow!("Multiple chips found for this project. Please specify one. Available chips: {}", chips.iter().map(|chip| chip.name))),
-            1 => chips.iter().first().unwrap(),
+            0 => {
+                return Err(Error::Other(anyhow!(
+                    "No chips have been configured for this project. Add one to the project first."
+                )))
+            }
+            1 => chips.iter().next().unwrap(),
+            _ => return Err(Error::Other(anyhow!(
+                "Multiple chips found for this project. Please specify one. Available chips: {:?}",
+                chips.iter().map(|chip| chip.name.clone())
+            ))),
         }
     };
 
-    let binaries = chip.binaries;
-    let binary = if let Some(version) = option.version {
-        binaries.find(|bin| bin.version == version).ok_or_else(|| anyhow!("Binary version {version} not found for chip {}. Available versions: {}", chip.name, binaries.iter().map(|bin| bin.version)))?
+    let binaries = &chip.binaries;
+    let binary = if let Some(version) = version {
+        binaries
+            .iter()
+            .find(|bin| bin.version() == version)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Binary version {version} not found for chip {}. Available versions: {:?}",
+                    chip.name,
+                    binaries.iter().map(|bin| bin.version())
+                )
+            })?
     } else {
         match binaries.len() {
-            0 => return Err(anyhow!("No binaries have been configured for chip {}. Add a binary to this chip first.", chip.name)),
-            n => return Err(anyhow!("Multiple binaries found for chip {}. Please specify one. Available versions: {}", chip.name, binaries.iter().map(|bin| bin.version))),
-            1 => binaries.iter().first().unwrap(),
+            0 => return Err(Error::Other(anyhow!(
+                "No binaries have been configured for chip {}. Add a binary to this chip first.",
+                chip.name
+            ))),
+            1 => binaries.iter().next().unwrap(),
+            _ => return Err(Error::Other(anyhow!(
+                "Multiple binaries found for chip {}. Please specify one. Available versions: {:?}",
+                chip.name,
+                binaries.iter().map(|bin| bin.version())
+            ))),
         }
     };
 
-    let result = run_flash_download(chip.name, binary.parts);
+    let result = run_flash_download(client, &chip, binary).await;
 
     if result.is_err() {
         println!("❌ Flashing procedure failed.");
@@ -53,7 +90,11 @@ pub async fn download(client: &mut forged::Client, chip: Option<String>, version
     Ok(())
 }
 
-fn run_flash_download(chip: impl AsRef<str>, parts: Vec<BinaryPart>) -> Result<()> {
+async fn run_flash_download(
+    client: &mut forged::Client,
+    chip: &Chip,
+    binary: &Binary,
+) -> Result<()> {
     let probe = Probe::list_all()
         .get(0)
         .ok_or_else(|| anyhow!("No probe found"))?
@@ -66,33 +107,34 @@ fn run_flash_download(chip: impl AsRef<str>, parts: Vec<BinaryPart>) -> Result<(
     }
 
     // Create a new session
-    let mut session = probe.attach(chip.as_ref(), probe_rs::Permissions::default())?;
+    let mut session = probe.attach(&chip.name, probe_rs::Permissions::default())?;
 
     let target = session.target();
 
     // Create the flash loader
     let mut loader = FlashLoader::new(target.memory_map.to_vec(), target.source().clone());
 
-    let n_parts = parts.len();
-    for (index, part) in parts.into_iter().enumerate() {
-
+    let n_parts = binary.parts.len();
+    for (index, part) in binary.parts.clone().into_iter().enumerate() {
         // TODO: Download the actual binary from the server
-        let binary = client.binary_part(binary_id, part_id)?;
+        let binary = client
+            .binary_part(chip.id, binary.id, part.id, None)
+            .await?;
 
         println!(
-            "📦 Flashing part {index}/{n_parts} with {} bytes to target",
-            part.analysis.nvm_size
+            "📦 Flashing part {index}/{n_parts}{}",
+            part.analysis
+                .map(|analysis| format!(" ({} bytes)", analysis.nvm_size))
+                .unwrap_or_default()
         );
 
         match part.kind {
             crate::queries::BinaryKind::Elf => loader
-                .load_elf_data(&mut Cursor::new(
-                    part.image.into_iter().map(|v| v as u8).collect::<Vec<_>>(),
-                ))
+                .load_elf_data(&mut Cursor::new(binary))
                 .map_err(|_| anyhow!("Failed to flash."))?,
             crate::queries::BinaryKind::Bin => loader
                 .load_bin_data(
-                    &mut Cursor::new(part.image.into_iter().map(|v| v as u8).collect::<Vec<_>>()),
+                    &mut Cursor::new(binary),
                     BinOptions {
                         base_address: part.memory_offset.map(|o| o as u64),
                         skip: 0,
@@ -100,9 +142,7 @@ fn run_flash_download(chip: impl AsRef<str>, parts: Vec<BinaryPart>) -> Result<(
                 )
                 .map_err(|_| anyhow!("Failed to flash."))?,
             crate::queries::BinaryKind::Hex => loader
-                .load_hex_data(&mut Cursor::new(
-                    part.image.into_iter().map(|v| v as u8).collect::<Vec<_>>(),
-                ))
+                .load_hex_data(&mut Cursor::new(binary))
                 .map_err(|_| anyhow!("Failed to flash."))?,
         }
     }

--- a/forged-cli/src/functions/download.rs
+++ b/forged-cli/src/functions/download.rs
@@ -139,7 +139,6 @@ async fn run_flash_download(
 
     let n_parts = binary.parts.len();
     for (index, part) in binary.parts.clone().into_iter().enumerate() {
-        // TODO: Download the actual binary from the server
         let binary = client
             .binary_part(chip.id, binary.id, part.id, None)
             .await?;

--- a/forged-cli/src/functions/download.rs
+++ b/forged-cli/src/functions/download.rs
@@ -145,7 +145,8 @@ async fn run_flash_download(
             .await?;
 
         println!(
-            "📦 Flashing part {index}/{n_parts}{}",
+            "📦 Flashing part {}/{n_parts}{}",
+            index + 1,
             part.analysis
                 .map(|analysis| format!(" ({} bytes)", analysis.nvm_size))
                 .unwrap_or_default()

--- a/forged-cli/src/functions/download.rs
+++ b/forged-cli/src/functions/download.rs
@@ -12,19 +12,38 @@ use probe_rs_cli_util::{
 };
 
 use crate::{
-    queries::{BinaryNewest, BinaryPart},
+    queries::{Chips, BinaryPart},
     Result,
 };
 
-pub async fn download(client: &mut forged::Client) -> Result<()> {
+pub async fn download(client: &mut forged::Client, chip: Option<String>, version: Option<String>) -> Result<()> {
     println!("⛅ Grabbing binaries from the server ...");
-    let query = client.run_query(BinaryNewest::build(())).await?;
-    let binary = query
-        .current_provisioner
-        .project
-        .binary_newest
-        .ok_or_else(|| anyhow::anyhow!("No binaries present"))?;
-    let result = run_flash_download(query.current_provisioner.project.chip.name, binary.parts);
+
+    let query = client.run_query(Chips::build(())).await?;
+    let chips = query.current_provisioner.project.chips;
+
+    let chip = if let Some(chip_name) = option.chip {
+        chips.find(|chip| chip.name == chip_name).ok_or_else(|| anyhow!("Chip {chip_name} not found. Available chips: {}", chips.iter().map(|chip| chip.name)))?
+    } else {
+        match chips.len() {
+            0 => return Err(anyhow!("No chips have been configured for this project. Add one to the project first.")),
+            n => return Err(anyhow!("Multiple chips found for this project. Please specify one. Available chips: {}", chips.iter().map(|chip| chip.name))),
+            1 => chips.iter().first().unwrap(),
+        }
+    };
+
+    let binaries = chip.binaries;
+    let binary = if let Some(version) = option.version {
+        binaries.find(|bin| bin.version == version).ok_or_else(|| anyhow!("Binary version {version} not found for chip {}. Available versions: {}", chip.name, binaries.iter().map(|bin| bin.version)))?
+    } else {
+        match binaries.len() {
+            0 => return Err(anyhow!("No binaries have been configured for chip {}. Add a binary to this chip first.", chip.name)),
+            n => return Err(anyhow!("Multiple binaries found for chip {}. Please specify one. Available versions: {}", chip.name, binaries.iter().map(|bin| bin.version))),
+            1 => binaries.iter().first().unwrap(),
+        }
+    };
+
+    let result = run_flash_download(chip.name, binary.parts);
 
     if result.is_err() {
         println!("❌ Flashing procedure failed.");
@@ -56,9 +75,13 @@ fn run_flash_download(chip: impl AsRef<str>, parts: Vec<BinaryPart>) -> Result<(
 
     let n_parts = parts.len();
     for (index, part) in parts.into_iter().enumerate() {
+
+        // TODO: Download the actual binary from the server
+        let binary = client.binary_part(binary_id, part_id)?;
+
         println!(
             "📦 Flashing part {index}/{n_parts} with {} bytes to target",
-            part.image.len()
+            part.analysis.nvm_size
         );
 
         match part.kind {

--- a/forged-cli/src/functions/end.rs
+++ b/forged-cli/src/functions/end.rs
@@ -1,15 +1,10 @@
 use cynic::MutationBuilder;
 
-use crate::{
-    queries::{FinishDeviceArguments, FinishRun},
-    Result,
-};
+use crate::{queries::FinishRun, Result};
 
 pub async fn end(client: &mut forged::Client) -> Result<()> {
     eprintln!("Finishing current device ...");
-    client
-        .run_query(FinishRun::build(&FinishDeviceArguments {}))
-        .await?;
+    client.run_query(FinishRun::build(())).await?;
 
     Ok(())
 }

--- a/forged-cli/src/functions/log.rs
+++ b/forged-cli/src/functions/log.rs
@@ -34,7 +34,7 @@ fn parse_log_entry(line: &str) -> CreateLogArguments {
     }
 }
 
-async fn generate_log(client: &forged::Client, args: &CreateLogArguments) -> Result<()> {
+async fn generate_log(client: &forged::Client, args: CreateLogArguments) -> Result<()> {
     println!("🪵  Logging: [{}] {}", args.level, args.message);
     client.run_query(CreateLog::build(args)).await?;
     Ok(())
@@ -60,12 +60,12 @@ pub async fn log(client: &mut forged::Client, options: LogOption) -> Result<()> 
             for line in BufReader::new(input).lines() {
                 let parsed_log =
                     parse_log_entry(&line.map_err(|e| anyhow!("Failed to read line: {e}"))?);
-                generate_log(client, &parsed_log).await?;
+                generate_log(client, parsed_log).await?;
             }
         }
 
         LogOption::Entry { level, message } => {
-            generate_log(client, &CreateLogArguments { level, message }).await?;
+            generate_log(client, CreateLogArguments { level, message }).await?;
         }
     }
 

--- a/forged-cli/src/main.rs
+++ b/forged-cli/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Command::Start => start(&mut client).await?,
-        Command::Download => download(&mut client).await?,
+        Command::Download { chip, version } => download(&mut client, chip, version).await?,
         Command::Log(option) => log(&mut client, option).await?,
         Command::Attach { file_path } => attach(&mut client, file_path).await?,
         Command::Block { data, schema_name } => block(&mut client, schema_name, data).await?,

--- a/forged-cli/src/main.rs
+++ b/forged-cli/src/main.rs
@@ -52,6 +52,7 @@ pub enum Error {
     Probe(#[from] probe_rs::Error),
     FlashOperation(#[from] probe_rs_cli_util::common_options::OperationError),
     Other(#[from] anyhow::Error),
+    Semver(#[from] semver::Error),
 }
 
 impl Display for Error {
@@ -64,6 +65,7 @@ impl Display for Error {
             }
             Error::Other(error) => writeln!(f, "{error}"),
             Error::FlashOperation(error) => writeln!(f, "{error}"),
+            Error::Semver(error) => writeln!(f, "Version format error: {error}"),
         }
     }
 }

--- a/forged-cli/src/queries.rs
+++ b/forged-cli/src/queries.rs
@@ -51,6 +51,7 @@ pub mod queries {
     pub struct Chip {
         pub id: Uuid,
         pub name: String,
+        pub part_number: String,
         pub binaries: Vec<Binary>,
     }
 
@@ -82,11 +83,14 @@ pub mod queries {
     }
 
     impl Binary {
-        pub fn version(&self) -> String {
-            format!(
-                "{}.{}.{}",
-                self.version_major, self.version_minor, self.version_patch
-            )
+        pub fn version(&self) -> semver::Version {
+            semver::Version {
+                major: self.version_major as u64,
+                minor: self.version_minor as u64,
+                patch: self.version_patch as u64,
+                pre: Default::default(),
+                build: Default::default(),
+            }
         }
     }
 

--- a/forged-cli/src/queries.rs
+++ b/forged-cli/src/queries.rs
@@ -54,28 +54,28 @@ pub mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Provisioner")]
-    pub struct ProvisionerBinary {
-        pub project: ProjectBinary,
-    }
-
-    #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "Chip")]
     pub struct Chip {
+        pub id: Uuid,
         pub name: String,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Project")]
-    pub struct ProjectBinary {
-        pub binary_newest: Option<Binary>,
-        pub chip: Chip,
+    #[cynic(graphql_type = "QueryRoot")]
+    pub struct Chips {
+        pub current_provisioner: ProvisionerProjectChips,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "QueryRoot")]
-    pub struct BinaryNewest {
-        pub current_provisioner: ProvisionerBinary,
+    #[cynic(graphql_type = "Project")]
+    pub struct ProjectChips {
+        pub chips: Vec<Chip>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Provisioner")]
+    pub struct ProvisionerProjectChips {
+        pub project: ProjectChips,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -89,7 +89,13 @@ pub mod queries {
         pub id: Uuid,
         pub kind: BinaryKind,
         pub memory_offset: Option<i32>,
+        pub analysis: BinaryPartAnalysis,
         pub image: Vec<i32>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct BinaryPartAnalaysis {
+        nvm_size: i32,
     }
 
     #[derive(cynic::Enum, Debug, Clone)]

--- a/forged-rs/CHANGELOG.md
+++ b/forged-rs/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+* Added a new `Client::binary_part()` API to download binary parts to the local machine and get
+their contents
+    * Downloaded contents are cached in $HOME/.forged
+
 ## 0.3.0 - 2023-05-05
 
 ### Added

--- a/forged-rs/Cargo.toml
+++ b/forged-rs/Cargo.toml
@@ -23,9 +23,14 @@ keywords = ["forged", "api", "client", "hardware", "provision"]
 [dependencies]
 regex = "1"
 log = "0.4"
+home = "0.5"
+sha2 = "0.10"
+uuid = { version = "1", features = ["serde"] }
+tokio = { version = "1", features = ["fs"]}
 cynic = { version = "2", features = ["http-reqwest"] }
-reqwest = { version = "0.11", features = ["json", "multipart"] }
+reqwest = { version = "0.11", features = ["json", "multipart", "stream"] }
 serde_json = "1.0.75"
 serde = "1"
 anyhow = "1.0.53"
 thiserror = "1.0.30"
+futures-util = "0.3"

--- a/forged-rs/schema.graphql
+++ b/forged-rs/schema.graphql
@@ -24,15 +24,20 @@ type Attachment {
 
 type Binary {
 	id: UUID!
-	projectId: UUID!
+	creationDate: DateTime!
+	deletionDate: DateTime
+	chipId: UUID!
+	chip: Chip!
+	version: String!
 	versionMajor: Int!
 	versionMinor: Int!
 	versionPatch: Int!
+	analysis: BinaryAnalysis
+	active: Boolean!
 	parts: [BinaryPart!]!
-	project: Project!
-	"""
-	Get the size of the binary non-volatile memory in bytes.
-	"""
+}
+
+type BinaryAnalysis {
 	nvmSize: Int!
 }
 
@@ -48,11 +53,15 @@ type BinaryPart {
 	binaryId: UUID!
 	kind: BinaryKind!
 	memoryOffset: Int
-	image: [Int!]!
 	imageHash: [Int!]!
-	sizeInMemory: Int!
+	analysis: BinaryPartAnalysis
 	creationDate: NaiveDateTime!
 	changeDate: NaiveDateTime!
+}
+
+type BinaryPartAnalysis {
+	rtt: RttAnalysis!
+	nvmSize: Int!
 }
 
 type Block {
@@ -79,10 +88,8 @@ type Block {
 	
 	This automatically transfers the stored data into a slice of bytes which can be written
 	to device memory.
-	
-	Uses [`BlockSchema::to_bytes`] to transform the data.
 	"""
-	byteSlice: [Int!]!
+	byteSlice(chipId: UUID!): [Int!]!
 }
 
 type BlockSchema {
@@ -90,43 +97,69 @@ type BlockSchema {
 	isDeviceIdentifier: Boolean!
 	projectId: UUID!
 	name: String!
+	displayName: String!
 	schema: String!
 	generator: String
-	toBytes: String
-	fromBytes: String
-	memoryAddress: Int
-	length: Int
-	creationDate: NaiveDateTime!
-	deactivationDate: NaiveDateTime
-	source: BlockSource!
+	memorySource: MemoryEndpoint
+	memorySink(chipId: UUID!): MemoryEndpoint!
+	memorySinks: [MemoryEndpoint!]!
+	creationDate: DateTime!
 	active: Boolean!
+	deletionDate: DateTime
 	"""
 	Determine if this schema can be used for requirements.
 	"""
 	supportsRequirements: Boolean!
-}
-
-"""
-Indicates the source of data for a block.
-"""
-enum BlockSource {
-	INPUT
-	EXTERNAL
-	DERIVED
+	requirements: [Requirement!]!
 }
 
 
 type Chip {
+	id: UUID!
+	projectId: UUID!
 	name: String!
-	nvmSize: Int!
+	partNumber: String!
+	nvmSize: Int
+	active: Boolean!
+	creationDate: DateTime!
+	changeDate: DateTime!
+	deletionDate: DateTime
+	"""
+	Returns true if the chip part number is natively supported by probe-rs.
+	"""
+	isSupported: Boolean!
+	"""
+	Returns the newest binary for given project id according to semver.
+	"""
+	binaryNewest: Binary
+	binaries: [Binary!]!
+	binary(id: UUID!): Binary!
 }
+
+input ChipEndpoint {
+	chipId: UUID!
+	address: Int!
+	length: Int!
+	transform: String!
+}
+
+type DataBlock {
+	blockSchema: BlockSchema!
+}
+
+"""
+Implement the DateTime<Utc> scalar
+
+The input/output is a string in RFC3339 format.
+"""
+scalar DateTime
 
 type Device {
 	id: UUID!
 	name: String
 	projectId: UUID!
-	creationDate: NaiveDateTime!
-	changeDate: NaiveDateTime!
+	creationDate: DateTime!
+	changeDate: DateTime!
 	project: Project!
 	runs: [Run!]!
 	"""
@@ -135,6 +168,14 @@ type Device {
 	If no UUID is given, the most recent run is returned.
 	"""
 	run(id: UUID): Run!
+	"""
+	Whether or not the device is active.
+	"""
+	active: Boolean!
+	"""
+	The date when the device was deactivated.
+	"""
+	deletionDate: DateTime
 }
 
 type DeviceConnection {
@@ -158,13 +199,13 @@ An edge in a connection.
 """
 type DeviceEdge {
 	"""
-	A cursor for use in pagination
-	"""
-	cursor: String!
-	"""
 	The item at the end of the edge
 	"""
 	node: Device!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 type Family {
@@ -173,11 +214,80 @@ type Family {
 	owner: Owner!
 }
 
+input FinishStepData {
+	binaryId: UUID
+}
+
+type FlashChip {
+	chipId: UUID!
+	command: String
+	chip: Chip!
+}
+
 
 type Group {
 	id: UUID!
+	name: String!
+	users: [User!]!
+	creationDate: DateTime!
+	changeDate: DateTime!
+	projects: [Project!]!
 }
 
+
+input InputDataBlock {
+	blockSchemaId: UUID
+}
+
+input InputFlashChip {
+	chipId: UUID
+	command: String
+}
+
+input InputIntegrationsSettings {
+	telegram: InputTelegramSettings!
+	matrix: InputMatrixSettings!
+}
+
+input InputMatrixSettings {
+	rooms: [String!]!
+}
+
+input InputPlaybook {
+	version: Int
+	stations: [InputStation!]!
+}
+
+input InputProjectSettings {
+	integrations: InputIntegrationsSettings!
+}
+
+input InputRunCommand {
+	command: String
+	directory: String
+}
+
+input InputStation {
+	name: String
+	color: String
+	steps: [InputStep!]!
+}
+
+input InputStep {
+	id: UUID!
+	label: String
+	kind: InputStepKind!
+}
+
+input InputStepKind {
+	dataBlock: InputDataBlock
+	flashChip: InputFlashChip
+	runCommand: InputRunCommand
+}
+
+input InputTelegramSettings {
+	chatIds: [Int!]!
+}
 
 input InsertBinaryPart {
 	name: String
@@ -186,6 +296,11 @@ input InsertBinaryPart {
 	image: Upload!
 }
 
+
+type IntegrationsSettings {
+	telegram: TelegramSettings!
+	matrix: MatrixSettings!
+}
 
 """
 A scalar that can represent any JSON value.
@@ -197,8 +312,26 @@ type Log {
 	runId: UUID!
 	level: String!
 	message: String!
-	creationDate: NaiveDateTime!
+	creationDate: DateTime!
 	run: Run!
+}
+
+type MatrixSettings {
+	rooms: [String!]!
+}
+
+scalar MemoryAddress
+
+type MemoryEndpoint {
+	id: UUID!
+	schema: BlockSchema!
+	chip: Chip!
+	sink: Boolean!
+	address: MemoryAddress!
+	length: Int!
+	creationDate: DateTime!
+	active: Boolean!
+	deletionDate: DateTime
 }
 
 type MutationRoot {
@@ -206,7 +339,11 @@ type MutationRoot {
 	Creates a new device for given `project_id` and returns the device.
 	"""
 	deviceCreate: Device!
-	signIn(username: String!, password: String!): String!
+	"""
+	Delete a device, making it no longer appear as being linked to the project.
+	"""
+	deviceDelete(id: UUID!): UUID!
+	signIn(email: String!, password: String!): String!
 	"""
 	Sign in with a given OAuth provider.
 	
@@ -218,8 +355,8 @@ type MutationRoot {
 	This nonce is only required for real OIDC providers and not all OAuth providers.
 	"""
 	signInWithOauth(provider: String!, code: String!, csrfToken: String, nonce: String): String!
-	refresh(token: String!): String!
-	userCreate(username: String!, email: String!, password: String!): User!
+	refresh(token: String!, impersonate: UUID): String!
+	userCreate(email: String!, password: String!): User!
 	userConfirm(token: String!): Boolean!
 	userApprove(id: UUID!): UUID!
 	userResendConfirmCode(email: String!): Boolean!
@@ -230,16 +367,36 @@ type MutationRoot {
 	"""
 	changePassword(currentPassword: String!, newPassword: String!): Boolean!
 	"""
-	Creates a new binary record and retursn the ID of the created record.
+	Creates a new binary with the specified chip
 	"""
-	binaryCreate(projectId: UUID!, version: String!, parts: [InsertBinaryPart!]!): Binary!
+	binaryCreate(chipId: UUID!, version: String!, parts: [InsertBinaryPart!]!): Binary!
+	"""
+	Delete a binary, making it no longer appear as being linked to the project.
+	"""
+	binaryDelete(id: UUID!): UUID!
 	"""
 	Creates a new project for a user and returns the project upon successful creation.
 	"""
-	projectCreate(name: String!, chipName: String!): Project!
-	provisionerCreate(name: String!, projectId: UUID!): Provisioner!
+	projectCreate(name: String!, groupOwner: UUID): Project!
+	"""
+	Delete a project, making it no longer appear as being linked to the user.
+	"""
+	projectDelete(id: UUID!): UUID!
+	"""
+	Change the owner of a project to a new user or group
+	"""
+	projectTransfer(id: UUID!, ownerId: UUID!): UUID!
+	"""
+	Update settings on a project.
+	"""
+	projectSettingsUpdate(id: UUID!, settings: InputProjectSettings!): UUID!
+	provisionerCreate(name: String!, station: String!, projectId: UUID!): Provisioner!
 	provisionerRename(id: UUID!, name: String!): Provisioner!
-	provisionerDeactivate(id: UUID!): Provisioner!
+	provisionerAssignStation(id: UUID!, station: String!): Provisioner!
+	"""
+	Delete a provisioner, making it no longer appear as being linked to the project.
+	"""
+	provisionerDelete(id: UUID!): UUID!
 	provisionerRegenerateToken(id: UUID!): Provisioner!
 	"""
 	Creates a new log for given `project_id` and returns the log.
@@ -264,13 +421,16 @@ type MutationRoot {
 	"""
 	Creates a new block_schema and returns the block_schema.
 	"""
-	blockSchemaCreate(projectId: UUID!, name: String!, schema: String!, generator: String, toBytes: String, fromBytes: String, memoryAddress: Int, length: Int, source: BlockSource!, isDeviceIdentifier: Boolean!): BlockSchema!
+	blockSchemaCreate(projectId: UUID!, name: String!, schema: String!, generator: String, memorySource: ChipEndpoint, memorySinks: [ChipEndpoint!]!, isDeviceIdentifier: Boolean!): BlockSchema!
 	"""
 	Re-name a block schema
 	"""
 	blockSchemaRename(id: UUID!, name: String!): UUID!
 	blockSchemaSetIdentifier(id: UUID!, identifier: Boolean!): UUID!
-	blockSchemaDeactivate(id: UUID!): BlockSchema!
+	"""
+	Delete a block schema, making it no longer appear as being linked to the project.
+	"""
+	blockSchemaDelete(id: UUID!): UUID!
 	"""
 	Creates a new block for given `project_id` and returns the block.
 	"""
@@ -279,7 +439,11 @@ type MutationRoot {
 	"""
 	Creates a new run for the currently in-session device and returns the run.
 	"""
-	runCreate: Run!
+	runCreate(station: String!): Run!
+	"""
+	Creates a new run for an existing device and returns the run.
+	"""
+	runCreateFor(identifier: String!, station: String!): Run!
 	"""
 	Finish provisioning for a run.
 	"""
@@ -291,15 +455,31 @@ type MutationRoot {
 	"""
 	Start a provisioning step on the currently-active run.
 	"""
-	finishStep(passed: Boolean!): UUID!
+	finishStep(passed: Boolean!, data: FinishStepData): UUID!
 	"""
 	Create a new requirement for given `project_id`.
 	"""
 	requirementCreate(projectId: UUID!, schemaId: UUID!, name: String!, description: String, lowerLimit: Float, inclusiveLower: Boolean!, upperLimit: Float, inclusiveUpper: Boolean!): Requirement!
 	"""
-	Deactivate a requirement such that it is no longer checked.
+	Delete a requirement,making it no longer linked to the project.
 	"""
-	requirementDeactivate(id: UUID!): UUID!
+	requirementDelete(id: UUID!): UUID!
+	"""
+	Updates the draft playbook with the given new playbook.
+	"""
+	playbookUpdate(projectId: UUID!, playbook: InputPlaybook!): Boolean!
+	playbookSave(projectId: UUID!): Int!
+	"""
+	Creates a new project for a user and returns the project upon successful creation.
+	"""
+	chipCreate(projectId: UUID!, name: String!, partNumber: String!): Chip!
+	"""
+	Delete a chip, making it no longer appear as being linked to the project.
+	"""
+	chipDelete(id: UUID!): UUID!
+	groupCreate(name: String!): Group!
+	groupAddUser(groupId: UUID!, userEmail: String!): UUID!
+	groupRemoveUser(groupId: UUID!, userId: UUID!): UUID!
 }
 
 """
@@ -310,6 +490,46 @@ ISO 8601 combined date and time without timezone.
 * `2015-07-01T08:59:60.123`,
 """
 scalar NaiveDateTime
+
+type Notification {
+	id: UUID!
+	projectId: UUID
+	event: JSON!
+	retry: Int!
+	creationDate: DateTime!
+	deliveryDate: DateTime
+	project: Project
+}
+
+type NotificationConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [NotificationEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Notification!]!
+	numNotifications: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type NotificationEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Notification!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
 
 type OauthData {
 	authUrl: String!
@@ -350,16 +570,32 @@ type PaymentMethod {
 	id: String!
 }
 
+type Playbook {
+	projectId: UUID!
+	version: Int
+	stations: [Station!]!
+	station(name: String!): Station
+	project: Project!
+}
+
 type Project {
 	id: UUID!
 	name: String!
-	chip: Chip!
-	binary(id: UUID!): Binary!
+	active: Boolean!
+	settings: ProjectSettings!
+	creationDate: DateTime!
+	changeDate: DateTime!
+	deletionDate: DateTime
+	chip(id: UUID!): Chip!
 	"""
-	Returns the newest binary for given project id according to semver.
+	Get the currently-active playbook for the project.
 	"""
-	binaryNewest: Binary
-	binaries: [Binary!]!
+	playbook: Playbook!
+	"""
+	Get all playbooks registered with the project.
+	"""
+	playbooks: [Playbook!]!
+	chips: [Chip!]!
 	device(id: UUID!): Device!
 	devices(after: String, first: Int, filter: String): DeviceConnection!
 	owner: Owner!
@@ -369,6 +605,11 @@ type Project {
 	blockSchema(id: UUID!): BlockSchema!
 	requirements: [Requirement!]!
 	requirement(id: UUID!): Requirement!
+	notifications(after: String, first: Int, filter: String): NotificationConnection!
+}
+
+type ProjectSettings {
+	integrations: IntegrationsSettings!
 }
 
 type Provisioner {
@@ -378,11 +619,13 @@ type Provisioner {
 	name: String!
 	token: String
 	active: Boolean!
-	creationDate: NaiveDateTime!
-	changeDate: NaiveDateTime!
+	creationDate: DateTime!
+	changeDate: DateTime!
 	project: Project!
 	currentDevice: Device
 	currentRun: Run
+	station: String!
+	steps: [Step!]!
 }
 
 type ProvisionerReleases {
@@ -396,6 +639,11 @@ type QueryRoot {
 	config: AppConfig!
 	currentUser: User!
 	usersPendingApproval: [User!]!
+	users: [User!]!
+	"""
+	Lists all projects.
+	"""
+	projects: [Project!]!
 	"""
 	Returns a project with a certain `id`.
 	"""
@@ -428,6 +676,7 @@ type QueryRoot {
 	Returns the data that is required for the frontend to work.
 	"""
 	provisionerReleases: ProvisionerReleases!
+	group(id: UUID!): Group!
 }
 
 type Release {
@@ -453,11 +702,11 @@ type Requirement {
 	"""
 	The date that the requirement was created.
 	"""
-	creationDate: NaiveDateTime!
+	creationDate: DateTime!
 	"""
 	The date when the requirement was deactivated.
 	"""
-	deactivationDate: NaiveDateTime
+	deletionDate: DateTime
 	"""
 	Whether or not the requirement is active.
 	"""
@@ -493,26 +742,31 @@ type RequirementCheck {
 	requirementId: UUID!
 	blockId: UUID
 	passed: Boolean!
-	checkDate: NaiveDateTime!
+	checkDate: DateTime!
 	runId: UUID!
 	requirement: Requirement!
 	block: Block
 }
 
+type RttAnalysis {
+	headerLocation: Int
+}
+
 type Run {
 	id: UUID!
 	deviceId: UUID!
-	currentStep: String!
 	projectId: UUID!
-	currentStepStatus: StepStatus!
-	creationDate: NaiveDateTime!
-	changeDate: NaiveDateTime!
+	provisioner: Provisioner
+	station: String!
+	creationDate: DateTime!
+	changeDate: DateTime!
 	finished: Boolean!
 	device: Device!
 	logs: [Log!]!
 	attachments: [Attachment!]!
 	blocks: [Block!]!
 	block(id: UUID!): Block!
+	blockForSchema(schemaId: UUID!): Block
 	blockSchemas: [BlockSchema!]!
 	requirementChecks: [RequirementCheck!]!
 	requirements: [Requirement!]!
@@ -520,7 +774,52 @@ type Run {
 	Get the overall status of the run.
 	"""
 	runStatus: StepStatus!
+	steps: [RunStep!]!
+	"""
+	Reports any reasons for a run failure.
+	"""
+	errors: [String!]!
 }
+
+type RunCommand {
+	command: String
+	directory: String
+}
+
+type RunStep {
+	id: UUID!
+	runId: UUID!
+	stepId: UUID!
+	status: StepStatus!
+	station: String!
+	creationDate: DateTime!
+	changeDate: DateTime!
+	data: RunStepData!
+	step: Step!
+}
+
+type RunStepData {
+	binaryId: UUID
+	binary: Binary
+}
+
+type Station {
+	name: String!
+	color: String!
+	steps: [Step!]!
+}
+
+type Step {
+	id: UUID!
+	kind: StepKind!
+	position: Int!
+	station: String!
+	label: String
+	creationDate: NaiveDateTime!
+	changeDate: NaiveDateTime!
+}
+
+union StepKind = DataBlock | FlashChip | RunCommand
 
 enum StepStatus {
 	PENDING
@@ -544,6 +843,10 @@ type SubscriptionRoot {
 	"""
 	createDeviceEvent(token: String!, projectId: UUID!): Device!
 	"""
+	Yields a new requirement whenever one is created.
+	"""
+	createRequirementEvent(token: String!, projectId: UUID!): Requirement!
+	"""
 	Yields a new device whenever a new device is created.
 	"""
 	logEvent(token: String!, runId: UUID!): Log!
@@ -565,9 +868,22 @@ type Target {
 	name: String!
 }
 
+type TelegramSettings {
+	chatIds: [Int!]!
+}
+
 enum Tier {
+	"""
+	Only a very limited free featureset.
+	"""
 	FREE
+	"""
+	The basic service with all it's basic features.
+	"""
 	BASE
+	"""
+	The full featureset unlocked.
+	"""
 	FULL
 }
 
@@ -588,14 +904,13 @@ scalar Upload
 type User {
 	id: UUID!
 	stripeCustomerId: String
-	username: String!
 	email: String!
 	tier: Tier!
 	admin: Boolean!
 	userType: UserType!
 	oauthUser: OauthUser
-	creationDate: NaiveDateTime!
-	changeDate: NaiveDateTime!
+	creationDate: DateTime!
+	changeDate: DateTime!
 	projects: [Project!]!
 	families: [Family!]!
 	groups: [Group!]!
@@ -607,6 +922,8 @@ enum UserType {
 	OAUTH
 }
 
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
 	query: QueryRoot
 	mutation: MutationRoot

--- a/forged-rs/src/chips.rs
+++ b/forged-rs/src/chips.rs
@@ -1,0 +1,171 @@
+use crate::{Client, Error};
+use anyhow::anyhow;
+use cynic::impl_scalar;
+use cynic::QueryBuilder;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use futures_util::StreamExt;
+
+impl Client {
+    pub async fn binary_part(
+        &self,
+        binary_id: Uuid,
+        part_id: Uuid,
+        update_handler: Option<impl Fn(f64)>,
+    ) -> Result<Vec<u8>, Error> {
+        // Query the part hash
+        let result = self
+            .run_query(QueryBinaryPartHash::build(PartHashArguments { binary_id }))
+            .await?;
+
+        let Some(part) = result
+            .current_provisioner
+            .project
+            .binary
+            .parts
+            .iter()
+            .find(|part| part.id == part_id)
+        else {
+            return Err(anyhow!("Part not found").into());
+        };
+
+        self.fetch_url(result.current_provisioner.project.id, part, update_handler)
+            .await
+    }
+
+    async fn fetch_url(
+        &self,
+        project_id: Uuid,
+        part: &BinaryPart,
+        update_handler: Option<impl Fn(f64)>,
+    ) -> Result<Vec<u8>, Error> {
+        let url = format!(
+            "{api_url}/project/{project_id}/binary/{binary_id}/part/{part_id}",
+            api_url = self.instance_url,
+            binary_id = part.binary_id,
+            part_id = part.id,
+        );
+
+        if let Some(cache_folder) = &self.cache_folder {
+            let mut cache_file = cache_folder.clone();
+            cache_file.push(format!("{}", part.id));
+
+            log::info!("Reading the binary cache file at {cache_file:?}");
+            match tokio::fs::read(&cache_file).await {
+                Ok(file_content) => {
+                    let part_hash = part.image_hash.iter().map(|v| *v as u8).collect();
+                    let mut hasher = Sha256::new();
+                    hasher.update(&file_content);
+                    let image_hash = hasher.finalize();
+                    if image_hash == part_hash {
+                        log::info!("Read firmware from local cache");
+                        return Ok(file_content);
+                    } else {
+                        log::warn!("Cached file at {cache_file:?} is corrupt");
+
+                        if let Err(error) = tokio::fs::remove_file(&cache_file).await {
+                            log::warn!(
+                                "Removing the corrupt binary cache file at {cache_file:?} failed: {error}"
+                            );
+                            log::warn!("Please remove it manually!");
+                        };
+                    }
+                }
+                Err(error) => {
+                    log::info!("Reading the binary cache file at {cache_file:?} failed: {error}");
+                }
+            };
+        }
+
+        log::info!("Downloading firmware from remote");
+
+        let response = reqwest::Client::new()
+            .get(url)
+            .bearer_auth(self.token.clone())
+            .send()
+            .await?;
+
+        let total_size = response
+            .content_length()
+            .ok_or_else(|| Error::Api(anyhow!("Could not get total size.")))?;
+
+        let mut data: Vec<u8> = Vec::with_capacity(total_size as usize);
+        let mut downloaded: u64 = 0;
+        let mut stream = response.bytes_stream();
+
+        while let Some(item) = stream.next().await {
+            let chunk = item?;
+            data.extend(&chunk);
+            let new = core::cmp::min(downloaded + (chunk.len() as u64), total_size);
+            downloaded = new;
+            if let Some(update) = &update_handler {
+                update(downloaded as f64 / total_size as f64)
+            }
+        }
+        if let Some(update) = update_handler {
+            update(1.0)
+        }
+
+        if let Some(cache_folder) = &self.cache_folder {
+            let mut cache_file = cache_folder.clone();
+            cache_file.push(format!("{}", part.id));
+            if let Err(error) = tokio::fs::write(&cache_file, &data).await {
+                log::warn!("Writing the binary cache file at {cache_file:?} failed: {error}");
+            };
+        }
+
+        Ok(data)
+    }
+}
+
+pub use queries::*;
+
+#[cynic::schema_for_derives(file = "schema.graphql", module = "schema")]
+pub mod queries {
+    use super::schema;
+    use uuid::Uuid;
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "QueryRoot", variables = "PartHashArguments")]
+    pub struct QueryBinaryPartHash {
+        pub current_provisioner: Provisioner,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(variables = "PartHashArguments")]
+    pub struct Provisioner {
+        pub project: Project,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(variables = "PartHashArguments")]
+    pub struct Project {
+        #[arguments(id: $binary_id)]
+        pub binary: Binary,
+        pub id: Uuid,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct Binary {
+        pub parts: Vec<BinaryPart>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct BinaryPart {
+        pub id: Uuid,
+        pub binary_id: Uuid,
+        pub image_hash: Vec<i32>,
+    }
+
+    #[derive(cynic::QueryVariables, Debug)]
+    pub struct PartHashArguments {
+        pub binary_id: Uuid,
+    }
+}
+
+mod schema {
+    cynic::use_schema!("schema.graphql");
+}
+
+impl_scalar!(Uuid, schema::UUID);


### PR DESCRIPTION
Adds a new `forged-cli download` function that can be used to program chips + specific versions easily.

For example, when running on stabilizer:
```
$ cargo run -- download
   Compiling forged-cli v0.1.0 (C:\Users\rsummers\Documents\repositories\forged-org\forged-clients\forged-cli)
    Finished dev [unoptimized + debuginfo] target(s) in 6.75s
warning: the following packages contain code that will be rejected by a future version of Rust: svg v0.10.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 53`
     Running `target\debug\forged-cli.exe download`
 -> Flashing firmware v0.0.6 onto MCU (STM32H743ZITx)
⛅ Grabbing binaries from the server ...
📦 Flashing part 0/1 (337652 bytes)
     Reading flash   ✔ [00:00:01] [] 54.26KiB/54.26KiB @ 31.60KiB/s (eta 0s )
     Erasing sectors ✔ [00:00:05] [] 384.00KiB/384.00KiB @ 44.97KiB/s (eta 0s )
 Programming pages   ✔ [00:00:08] [] 384.00KiB/384.00KiB @ 24.69KiB/s (eta 0s )
    Finished in 15.417s

```